### PR TITLE
fix: align settings with groovy-lsp config keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For Jenkins shared libraries:
 ```json
 {
   // File patterns to recognize as Jenkinsfiles
-  "groovy.jenkins.filePatterns": ["Jenkinsfile", "*.jenkins", "*.jenkinsfile"],
+  "groovy.jenkins.filePatterns": ["Jenkinsfile", "vars/*.groovy"],
 
   // Configure shared libraries
   "groovy.jenkins.sharedLibraries": [
@@ -106,7 +106,12 @@ For Jenkins shared libraries:
   ],
 
   // GDSL files for DSL enhancements
-  "groovy.jenkins.gdslPaths": ["/path/to/jenkins.gdsl"]
+  "groovy.jenkins.gdslPaths": ["/path/to/jenkins.gdsl"],
+
+  // Optional: Jenkins plugin discovery overrides
+  "groovy.jenkins.pluginsTxtPath": "/path/to/plugins.txt",
+  "groovy.jenkins.plugins": ["workflow-basic-steps", "pipeline-model-definition"],
+  "groovy.jenkins.includeDefaultPlugins": true
 }
 ```
 
@@ -125,19 +130,13 @@ For Jenkins shared libraries:
 }
 ```
 
-### TODO Comment Scanning
+### REPL Settings
 
 ```json
 {
-  // Enable TODO/FIXME scanning
-  "groovy.todo.scanEnabled": true,
-
-  // Configure patterns and severity levels
-  "groovy.todo.patterns": {
-    "TODO": "Information",
-    "FIXME": "Warning",
-    "BUG": "Error"
-  }
+  "groovy.repl.enabled": true,
+  "groovy.repl.maxSessions": 10,
+  "groovy.repl.sessionTimeoutMinutes": 60
 }
 ```
 

--- a/client/src/configuration/settings.ts
+++ b/client/src/configuration/settings.ts
@@ -68,16 +68,19 @@ export function affectsCodeNarcConfiguration(event: ConfigurationChangeEvent): b
 export function affectsJenkinsConfiguration(event: ConfigurationChangeEvent): boolean {
     return affectsConfiguration(event, 'jenkins.filePatterns') ||
            affectsConfiguration(event, 'jenkins.sharedLibraries') ||
-           affectsConfiguration(event, 'jenkins.gdslPaths');
+           affectsConfiguration(event, 'jenkins.gdslPaths') ||
+           affectsConfiguration(event, 'jenkins.pluginsTxtPath') ||
+           affectsConfiguration(event, 'jenkins.plugins') ||
+           affectsConfiguration(event, 'jenkins.includeDefaultPlugins');
 }
 
 /**
- * Checks if a configuration change affects TODO scanning settings
+ * Checks if a configuration change affects REPL settings
  */
-export function affectsTodoConfiguration(event: ConfigurationChangeEvent): boolean {
-    return affectsConfiguration(event, 'todo.scanEnabled') ||
-           affectsConfiguration(event, 'todo.patterns') ||
-           affectsConfiguration(event, 'todo.semanticTokensEnabled');
+export function affectsReplConfiguration(event: ConfigurationChangeEvent): boolean {
+    return affectsConfiguration(event, 'repl.enabled') ||
+           affectsConfiguration(event, 'repl.maxSessions') ||
+           affectsConfiguration(event, 'repl.sessionTimeoutMinutes');
 }
 
 /**
@@ -88,7 +91,7 @@ export function requiresServerRestart(event: ConfigurationChangeEvent): boolean 
     return affectsJavaConfiguration(event) ||
            affectsConfiguration(event, 'server.path') ||
            affectsConfiguration(event, 'compilation.mode') ||
-           affectsJenkinsConfiguration(event);
+           affectsReplConfiguration(event);
 }
 
 /**
@@ -96,8 +99,8 @@ export function requiresServerRestart(event: ConfigurationChangeEvent): boolean 
  * These settings can be updated without restarting the server
  */
 export function canBeAppliedDynamically(event: ConfigurationChangeEvent): boolean {
-    return affectsCodeNarcConfiguration(event) ||
-           affectsTodoConfiguration(event) ||
+    return affectsJenkinsConfiguration(event) ||
+           affectsCodeNarcConfiguration(event) ||
            affectsConfiguration(event, 'format.enable') ||
            affectsConfiguration(event, 'server.maxNumberOfProblems') ||
            affectsConfiguration(event, 'trace.server') ||

--- a/client/src/configuration/watcher.ts
+++ b/client/src/configuration/watcher.ts
@@ -3,7 +3,7 @@ import {
     requiresServerRestart,
     canBeAppliedDynamically
 } from './settings';
-import { restartClient, getClient } from '../server/client';
+import { restartClient, getClient, buildServerSettingsMap } from '../server/client';
 
 /**
  * Sets up configuration change watchers
@@ -35,10 +35,10 @@ export function setupConfigurationWatcher(): Disposable {
             console.log('Configuration changed, notifying server...');
             const client = getClient();
             if (client) {
-                // The LSP client automatically sends workspace/didChangeConfiguration
-                // when configurationSection is set in client options
-                // No action needed here - just log for debugging
-                console.log('Server will be notified via workspace/didChangeConfiguration');
+                client.sendNotification('workspace/didChangeConfiguration', {
+                    settings: buildServerSettingsMap()
+                });
+                console.log('Sent workspace/didChangeConfiguration to server');
             }
         }
     });

--- a/client/src/server/client.ts
+++ b/client/src/server/client.ts
@@ -21,39 +21,12 @@ interface JenkinsSharedLibrary {
 }
 
 /**
- * LSP Server initialization options matching the server's configuration schema
+ * LSP Server initialization options.
+ *
+ * The Groovy LSP expects a flat map of string keys to values (not a nested object).
+ * See groovy-lsp `ServerConfiguration.fromMap(...)` / `JenkinsConfiguration.fromMap(...)`.
  */
-interface LspInitializationOptions {
-    server: {
-        maxNumberOfProblems: number;
-    };
-    compilation: {
-        mode: 'workspace' | 'single-file';
-        incrementalThreshold: number;
-        maxWorkspaceFiles: number;
-    };
-    codenarc: {
-        enabled: boolean;
-        propertiesFile?: string;
-        autoDetect: boolean;
-    };
-    jenkins: {
-        filePatterns: string[];
-        sharedLibraries: JenkinsSharedLibrary[];
-        gdslPaths: string[];
-    };
-    todo: {
-        scanEnabled: boolean;
-        patterns: Record<string, 'Error' | 'Warning' | 'Information' | 'Hint'>;
-        semanticTokensEnabled: boolean;
-    };
-    format: {
-        enable: boolean;
-    };
-    trace: {
-        server: 'off' | 'messages' | 'verbose';
-    };
-}
+type LspInitializationOptions = Record<string, unknown>;
 
 let client: LanguageClient | undefined;
 let context: ExtensionContext | undefined;
@@ -143,63 +116,60 @@ async function createServerOptions(): Promise<ServerOptions> {
 }
 
 /**
+ * Builds a flat settings map for the Groovy LSP server.
+ *
+ * Note: VS Code settings are namespaced under `groovy.*`, but the Groovy LSP uses:
+ * - `groovy.*` keys for core server settings
+ * - `jenkins.*` keys for Jenkins configuration
+ */
+export function buildServerSettingsMap(): Record<string, unknown> {
+    const config = workspace.getConfiguration('groovy');
+
+    const settings: Record<string, unknown> = {
+        'groovy.server.maxNumberOfProblems': config.get<number>('server.maxNumberOfProblems', 100),
+        'groovy.trace.server': config.get<'off' | 'messages' | 'verbose'>('trace.server', 'off'),
+
+        'groovy.compilation.mode': config.get<'workspace' | 'single-file'>('compilation.mode', 'workspace'),
+        'groovy.compilation.incrementalThreshold': config.get<number>('compilation.incrementalThreshold', 50),
+        'groovy.compilation.maxWorkspaceFiles': config.get<number>('compilation.maxWorkspaceFiles', 500),
+
+        'groovy.repl.enabled': config.get<boolean>('repl.enabled', true),
+        'groovy.repl.maxSessions': config.get<number>('repl.maxSessions', 10),
+        'groovy.repl.sessionTimeoutMinutes': config.get<number>('repl.sessionTimeoutMinutes', 60),
+
+        'groovy.codenarc.enabled': config.get<boolean>('codenarc.enabled', true),
+        'groovy.codenarc.autoDetect': config.get<boolean>('codenarc.autoDetect', true),
+
+        'jenkins.filePatterns': config.get<string[]>('jenkins.filePatterns', ['Jenkinsfile', 'vars/*.groovy']),
+        'jenkins.sharedLibraries': config.get<JenkinsSharedLibrary[]>('jenkins.sharedLibraries', []),
+        'jenkins.gdslPaths': config.get<string[]>('jenkins.gdslPaths', []),
+        'jenkins.plugins': config.get<string[]>('jenkins.plugins', []),
+        'jenkins.includeDefaultPlugins': config.get<boolean>('jenkins.includeDefaultPlugins', true),
+    };
+
+    const javaHome = config.get<string>('java.home');
+    if (typeof javaHome === 'string' && javaHome.trim().length > 0) {
+        settings['groovy.java.home'] = javaHome;
+    }
+
+    const codeNarcPropertiesFile = config.get<string>('codenarc.propertiesFile');
+    if (typeof codeNarcPropertiesFile === 'string' && codeNarcPropertiesFile.trim().length > 0) {
+        settings['groovy.codenarc.propertiesFile'] = codeNarcPropertiesFile;
+    }
+
+    const pluginsTxtPath = config.get<string>('jenkins.pluginsTxtPath');
+    if (typeof pluginsTxtPath === 'string' && pluginsTxtPath.trim().length > 0) {
+        settings['jenkins.pluginsTxtPath'] = pluginsTxtPath;
+    }
+
+    return settings;
+}
+
+/**
  * Builds initialization options from workspace configuration
  */
 function buildInitializationOptions(): LspInitializationOptions {
-    const config = workspace.getConfiguration('groovy');
-
-    return {
-        // Server configuration
-        server: {
-            maxNumberOfProblems: config.get<number>('server.maxNumberOfProblems', 100)
-        },
-
-        // Compilation settings
-        compilation: {
-            mode: config.get<'workspace' | 'single-file'>('compilation.mode', 'workspace'),
-            incrementalThreshold: config.get<number>('compilation.incrementalThreshold', 50),
-            maxWorkspaceFiles: config.get<number>('compilation.maxWorkspaceFiles', 500)
-        },
-
-        // CodeNarc static analysis
-        codenarc: {
-            enabled: config.get<boolean>('codenarc.enabled', true),
-            propertiesFile: config.get<string>('codenarc.propertiesFile'),
-            autoDetect: config.get<boolean>('codenarc.autoDetect', true)
-        },
-
-        // Jenkins pipeline support
-        jenkins: {
-            filePatterns: config.get<string[]>('jenkins.filePatterns', ['Jenkinsfile', '*.jenkins', '*.jenkinsfile']),
-            sharedLibraries: config.get<JenkinsSharedLibrary[]>('jenkins.sharedLibraries', []),
-            gdslPaths: config.get<string[]>('jenkins.gdslPaths', [])
-        },
-
-        // TODO/FIXME scanning
-        todo: {
-            scanEnabled: config.get<boolean>('todo.scanEnabled', true),
-            patterns: config.get<Record<string, 'Error' | 'Warning' | 'Information' | 'Hint'>>('todo.patterns', {
-                'TODO': 'Information',
-                'FIXME': 'Warning',
-                'XXX': 'Warning',
-                'HACK': 'Warning',
-                'NOTE': 'Information',
-                'BUG': 'Error',
-                'OPTIMIZE': 'Hint'
-            }),
-            semanticTokensEnabled: config.get<boolean>('todo.semanticTokensEnabled', true)
-        },
-
-        // Formatting
-        format: {
-            enable: config.get<boolean>('format.enable', true)
-        },
-
-        // Trace/debugging
-        trace: {
-            server: config.get<'off' | 'messages' | 'verbose'>('trace.server', 'off')
-        }
-    };
+    return buildServerSettingsMap();
 }
 
 /**
@@ -216,9 +186,7 @@ function createClientOptions(): LanguageClientOptions {
         ],
         synchronize: {
             // Notify the server about file changes to Groovy files in the workspace
-            fileEvents: workspace.createFileSystemWatcher('**/*.{groovy,gvy,gy,gsh,gradle,Jenkinsfile}'),
-            // Also notify about configuration changes for all groovy.* settings
-            configurationSection: 'groovy'
+            fileEvents: workspace.createFileSystemWatcher('**/*.{groovy,gvy,gy,gsh,gradle,Jenkinsfile}')
         },
         initializationOptions: buildInitializationOptions(),
         outputChannelName: 'Groovy Language Server',

--- a/client/src/server/client.ts
+++ b/client/src/server/client.ts
@@ -139,6 +139,7 @@ export function buildServerSettingsMap(): Record<string, unknown> {
 
         'groovy.codenarc.enabled': config.get<boolean>('codenarc.enabled', true),
         'groovy.codenarc.autoDetect': config.get<boolean>('codenarc.autoDetect', true),
+        'groovy.format.enable': config.get<boolean>('format.enable', true),
 
         'jenkins.filePatterns': config.get<string[]>('jenkins.filePatterns', ['Jenkinsfile', 'vars/*.groovy']),
         'jenkins.sharedLibraries': config.get<JenkinsSharedLibrary[]>('jenkins.sharedLibraries', []),

--- a/package.json
+++ b/package.json
@@ -205,6 +205,23 @@
           "minimum": 1,
           "description": "Maximum number of files to compile in workspace mode. Larger projects automatically use single-file mode."
         },
+        "groovy.repl.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the Groovy REPL integration"
+        },
+        "groovy.repl.maxSessions": {
+          "type": "number",
+          "default": 10,
+          "minimum": 1,
+          "description": "Maximum number of concurrent REPL sessions"
+        },
+        "groovy.repl.sessionTimeoutMinutes": {
+          "type": "number",
+          "default": 60,
+          "minimum": 1,
+          "description": "Idle timeout for REPL sessions (minutes)"
+        },
         "groovy.codenarc.enabled": {
           "type": "boolean",
           "default": true,
@@ -226,8 +243,7 @@
           },
           "default": [
             "Jenkinsfile",
-            "*.jenkins",
-            "*.jenkinsfile"
+            "vars/*.groovy"
           ],
           "description": "File patterns to recognize as Jenkins Pipeline files"
         },
@@ -265,37 +281,22 @@
           "default": [],
           "markdownDescription": "Paths to IntelliJ GDSL files for DSL enhancements. GDSL files provide dynamic method and property contributions for pipeline DSLs.\n\nExample: `[\"/path/to/jenkins.gdsl\"]`"
         },
-        "groovy.todo.scanEnabled": {
+        "groovy.jenkins.pluginsTxtPath": {
+          "type": "string",
+          "description": "Explicit path to Jenkins plugins.txt (overrides auto-discovery)"
+        },
+        "groovy.jenkins.plugins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Additional Jenkins plugins to include (plugin IDs, e.g. 'workflow-basic-steps')"
+        },
+        "groovy.jenkins.includeDefaultPlugins": {
           "type": "boolean",
           "default": true,
-          "description": "Enable TODO/FIXME comment scanning and reporting"
-        },
-        "groovy.todo.patterns": {
-          "type": "object",
-          "default": {
-            "TODO": "Information",
-            "FIXME": "Warning",
-            "XXX": "Warning",
-            "HACK": "Warning",
-            "NOTE": "Information",
-            "BUG": "Error",
-            "OPTIMIZE": "Hint"
-          },
-          "additionalProperties": {
-            "type": "string",
-            "enum": [
-              "Error",
-              "Warning",
-              "Information",
-              "Hint"
-            ]
-          },
-          "markdownDescription": "TODO comment patterns and their diagnostic severity levels.\n\nExample:\n```json\n{\n  \"TODO\": \"Information\",\n  \"FIXME\": \"Warning\",\n  \"HACK\": \"Error\"\n}\n```"
-        },
-        "groovy.todo.semanticTokensEnabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Use semantic tokens for TODO comment highlighting (requires LSP semantic tokens support)"
+          "description": "Include Groovy LSP built-in default Jenkins plugins (recommended)"
         }
       }
     }


### PR DESCRIPTION
- Make LSP initializationOptions and didChangeConfiguration payload a flat key/value map (as expected by groovy-lsp).
- Add missing VS Code settings that groovy-lsp actually parses (REPL + Jenkins plugin discovery).
- Align Jenkins filePatterns default with groovy-lsp and remove TODO settings that are not currently supported by groovy-lsp.