### PR TITLE
feat(update): finalize update checker UX + reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,30 @@ For Jenkins shared libraries:
 }
 ```
 
+### Update Checking
+
+The extension periodically checks for new Groovy Language Server releases.
+
+```json
+{
+  // Check for updates when extension starts
+  "groovy.update.checkOnStartup": true,
+
+  // Hours between automatic checks (minimum: 1)
+  "groovy.update.checkIntervalHours": 24,
+
+  // When to show notifications: "off", "onlyWhenOutdated", "always"
+  "groovy.update.notifications": "onlyWhenOutdated"
+}
+```
+
+Use `Groovy: Check for Language Server Updates` command to check manually.
+
 ## Commands
 
 - `Groovy: Restart Language Server` - Restart the language server if something goes wrong
 - `Groovy: Show Language Server Version` - Display the current LSP server version
+- `Groovy: Check for Language Server Updates` - Check for new LSP releases
 
 ## Development
 

--- a/client/src/features/update/GitHubReleaseProvider.ts
+++ b/client/src/features/update/GitHubReleaseProvider.ts
@@ -3,10 +3,12 @@ import { VersionChecker, ReleaseInfo, GitHubReleaseResponse } from './VersionChe
 
 /**
  * Production implementation of ReleaseProvider that fetches from GitHub API.
+ * Includes timeout handling to prevent hanging on slow networks.
  */
 export class GitHubReleaseProvider implements ReleaseProvider {
     private static readonly RELEASES_URL =
         'https://api.github.com/repos/GroovyLanguageServer/groovy-lsp/releases/latest';
+    private static readonly TIMEOUT_MS = 10_000;
 
     private readonly versionChecker: VersionChecker;
 
@@ -15,8 +17,12 @@ export class GitHubReleaseProvider implements ReleaseProvider {
     }
 
     async fetchLatestRelease(): Promise<ReleaseInfo | null> {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), GitHubReleaseProvider.TIMEOUT_MS);
+
         try {
             const response = await fetch(GitHubReleaseProvider.RELEASES_URL, {
+                signal: controller.signal,
                 headers: {
                     Accept: 'application/vnd.github.v3+json',
                     'User-Agent': 'vscode-groovy-extension'
@@ -31,8 +37,14 @@ export class GitHubReleaseProvider implements ReleaseProvider {
             const data = (await response.json()) as GitHubReleaseResponse;
             return this.versionChecker.buildReleaseInfo(data);
         } catch (error) {
-            console.error('Failed to fetch latest release:', error);
+            if (error instanceof Error && error.name === 'AbortError') {
+                console.warn('GitHub API request timed out');
+            } else {
+                console.error('Failed to fetch latest release:', error);
+            }
             return null;
+        } finally {
+            clearTimeout(timeoutId);
         }
     }
 }

--- a/client/src/features/update/UpdateService.ts
+++ b/client/src/features/update/UpdateService.ts
@@ -1,4 +1,4 @@
-import { Memento, window, env, Uri } from 'vscode';
+import { Memento, window, env, Uri, workspace } from 'vscode';
 import { UpdateChecker, UpdateCheckResult, VersionCache, SystemClock } from './index';
 import { GitHubReleaseProvider } from './GitHubReleaseProvider';
 import { getUpdateConfiguration, UpdateNotificationLevel } from '../../configuration/settings';
@@ -113,8 +113,8 @@ export class UpdateService {
     }
 
     /**
- * Shows update available notification with actions.
- */
+     * Shows update available notification with actions.
+     */
     private async showUpdateAvailable(result: UpdateCheckResult): Promise<void> {
         const latestVersion = result.latestRelease?.version || 'unknown';
         const releaseUrl = result.latestRelease?.releaseUrl;
@@ -122,10 +122,12 @@ export class UpdateService {
 
         const openReleaseAction = 'Open Release';
         const downloadAction = 'Download';
+        const dontShowAgainAction = "Don't Show Again";
 
         const actions: string[] = [];
         if (releaseUrl) actions.push(openReleaseAction);
         if (downloadUrl) actions.push(downloadAction);
+        actions.push(dontShowAgainAction);
 
         const action = await window.showInformationMessage(
             `Groovy Language Server ${latestVersion} is available! (current: ${result.currentVersion})`,
@@ -136,6 +138,9 @@ export class UpdateService {
             await env.openExternal(Uri.parse(releaseUrl));
         } else if (action === downloadAction && downloadUrl) {
             await env.openExternal(Uri.parse(downloadUrl));
+        } else if (action === dontShowAgainAction) {
+            await workspace.getConfiguration('groovy').update('update.notifications', 'off', true);
+            window.showInformationMessage('Update notifications disabled. Re-enable in Settings.');
         }
     }
 


### PR DESCRIPTION
## Summary

Final PR completing the update checker feature. Adds UX polish and reliability improvements.

## Changes

- **Don't Show Again action**: Users can disable update notifications directly from the notification
- **10s timeout**: Prevents hanging on slow/unresponsive networks using AbortController
- **README documentation**: Added Update Checking section with all settings

## Files Modified

| File | Changes |
|------|---------|
| `UpdateService.ts` | +Don't Show Again action |
| `GitHubReleaseProvider.ts` | +10s timeout with AbortController |
| `README.md` | +Update Checking section |

## Testing

- All 64 existing tests pass
- Lint clean
- TypeScript types check

## Full Feature Status

| PR | Description | Status |
|----|-------------|--------|
| #59 | Unit test infra + fast-check | ✅ Merged |
| #60 | VersionChecker + tests | ✅ Merged |
| #61 | VersionCache + tests | ✅ Merged |
| #62 | UpdateChecker orchestration | ✅ Merged |
| #63 | VS Code wiring | ✅ Merged |
| This PR | UX + Reliability | 🔄 |